### PR TITLE
A5 sticky sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,25 @@ vagrant ssh ctrl
 ### Finalize cluster setup
 Finally, you can run the following command from the host to finalize the cluster setup:
 ```bash
-ansible-playbook -u vagrant -i 192.168.56.100, finalization.yml 
+ansible-playbook -u vagrant -i 192.168.56.100, finalization-istio.yml 
 ```
+
+#### Sticky sessions
+After applying the canary release by running:
+```bash
+cd /vagrant
+kubectl apply -f canary-release.yml
+```
+, you should be able to utilize sticky sessions to determine which app version you are routed to.
+The users not selected for the experiment won't have the `x-user` header set, so they will be routed to v1:
+```bash
+curl http://app.local/
+```
+
+And users selected for the experiment will have `x-user: experiment` header set in the request, routing them to v2:
+```bash
+curl -H "x-user: experiment" http://app.local/
+``` 
 
 #### Local DNS Resolution
 On your host machine, make sure to add `app.local` and `dashboard.local` in your `/etc/hosts` file:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 # Configurable worker count
-WORKER_COUNT = ENV['WORKER_COUNT'] ? ENV['WORKER_COUNT'].to_i : 2
+WORKER_COUNT = ENV['WORKER_COUNT'] ? ENV['WORKER_COUNT'].to_i : 1
 
 Vagrant.configure("2") do |config|
   config.vm.box = "bento/ubuntu-24.04"
@@ -21,7 +21,7 @@ Vagrant.configure("2") do |config|
     # Control node basic setup
     ctrl.vm.provider "virtualbox" do |vb|
       # VM memory settings
-      # vb.memory = 4096
+#       vb.memory = 4096
       vb.memory = 2048
       vb.cpus = 2
       vb.name = "k8s-controller"
@@ -47,8 +47,8 @@ Vagrant.configure("2") do |config|
       node.vm.provider "virtualbox" do |vb|
         # VM memory settings
         # vb.memory = 6144
-        vb.memory = 2048
-        vb.cpus = 2
+        vb.memory = 4096
+        vb.cpus = 4
         vb.name = "k8s-worker-#{i}"
         # Uncomment if encounter startup issues
         vb.customize ["modifyvm", :id, "--usb", "off"]

--- a/ansible/general.yaml
+++ b/ansible/general.yaml
@@ -146,7 +146,7 @@
 
     - name: Install runc (1.1.12)
       apt:
-        name: runc=1.1.12*
+        name: runc
         state: present
         update_cache: yes
 

--- a/canary-release.yml
+++ b/canary-release.yml
@@ -230,17 +230,24 @@ spec:
   - "app.local"
   http:
   - match:
+    - headers:
+        x-user:
+          exact: "experiment"
+      uri:
+        prefix: /
+    route:
+    - destination:
+        host: app
+        subset: v2
+      weight: 100    
+  - match:
     - uri:
         prefix: /
     route:
     - destination:
         host: app
         subset: v1
-      weight: 50
-    - destination:
-        host: app
-        subset: v2
-      weight: 50
+      weight: 100
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService

--- a/canary-release.yml
+++ b/canary-release.yml
@@ -1,0 +1,263 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: model-v1
+  labels:
+    app: model-service
+    version: v1
+spec:
+  containers:
+  - name: model-service
+    image: ghcr.io/remla2025-team10/model-service:v0.0.5
+    ports:
+    - containerPort: 3000
+    env:
+    - name: PORT
+      value: "3000"
+    volumeMounts:
+    - name: model-volume
+      mountPath: /model-service/models
+  volumes:
+  - name: model-volume
+    hostPath:
+      path: ./
+      type: Directory
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: model-v2
+  labels:
+    app: model-service
+    version: v2
+spec:
+  containers:
+  - name: model-service
+    image: ghcr.io/remla2025-team10/model-service:v0.0.5   # Newer canary image version
+    ports:
+    - containerPort: 3000
+    env:
+    - name: PORT
+      value: "3000"
+    volumeMounts:
+    - name: model-volume
+      mountPath: /model-service/models
+  volumes:
+  - name: model-volume
+    hostPath:
+      path: ./
+      type: Directory
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app-v1
+  labels:
+    app: app-service
+    version: v1
+spec:
+  containers:
+  - name: app
+    image: ghcr.io/remla2025-team10/app-service:v0.5.2
+    ports:
+    - containerPort: 8080
+    env:
+    - name: PORT
+      value: "8080"
+    - name: MODEL_SERVICE_URL
+      value: "http://model-service:3000"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app-v2
+  labels:
+    app: app-service
+    version: v2
+spec:
+  containers:
+  - name: app
+    image: ghcr.io/remla2025-team10/app-service:v0.7.0   # Newer canary image version
+    ports:
+    - containerPort: 8080
+    env:
+    - name: PORT
+      value: "8080"
+    - name: MODEL_SERVICE_URL
+      value: "http://model-service:3000"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: model-service
+spec:
+  selector:
+    app: model-service
+  ports:
+  - name: http
+    port: 3000
+    targetPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app
+spec:
+  selector:
+    app: app-service
+  ports:
+  - name: http
+    port: 1234
+    targetPort: 8080
+---
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: my-gateway
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+  - port:
+      number: 443
+      name: https
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: dashboard-tls-secret   # Kubernetes secret with TLS cert/key
+    hosts:
+      - "dashboard.local"
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: model-service-dr
+spec:
+  host: model-service
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+  - name: v2
+    labels:
+      version: v2
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: app-dr
+spec:
+  host: app
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+  - name: v2
+    labels:
+      version: v2
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: prometheus-vs
+spec:
+  gateways:
+  - my-gateway
+  hosts:
+  - "prometheus.local"
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: prometheus.istio-system.svc.cluster.local
+        port:
+          number: 9090
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: kiali-vs
+spec:
+  gateways:
+  - my-gateway
+  hosts:
+  - "kiali.local"
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: kiali.istio-system.svc.cluster.local
+        port:
+          number: 20001
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: dashboard-vs
+spec:
+  gateways:
+  - my-gateway
+  hosts:
+  - "dashboard.local"
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: kubernetes-dashboard-kong-proxy
+        port:
+          number: 443
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: app-vs
+spec:
+  gateways:
+  - my-gateway
+  hosts:
+  - "app.local"
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: app
+        subset: v1
+      weight: 50
+    - destination:
+        host: app
+        subset: v2
+      weight: 50
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: model-service-vs
+spec:
+  hosts:
+  - model-service
+  http:
+  - match:
+    - sourceLabels:
+        version: v2
+    route:
+    - destination:
+        host: model-service
+        subset: v2
+  - route:  # default route
+    - destination:
+        host: model-service
+        subset: v1

--- a/canary-release.yml
+++ b/canary-release.yml
@@ -161,6 +161,11 @@ spec:
   - name: v2
     labels:
       version: v2
+  # Adding stickiness for pod in case we add more replicas
+  trafficPolicy:
+    loadBalancer:
+      consistentHash:
+        httpHeaderName: x-user
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService

--- a/finalization-istio.yml
+++ b/finalization-istio.yml
@@ -1,0 +1,164 @@
+- name: Finalizing Cluster Setup
+  hosts: all
+  become: true
+  vars:
+    istio_version: "1.22.0"  # You can update this version as needed
+    istio_install_dir: "/opt/istio"
+
+  tasks:
+    ########## Install Istio ##########
+    - name: Ensure curl is installed
+      apt:
+        name: curl
+        state: present
+        update_cache: yes
+
+    - name: Create Istio install directory
+      file:
+        path: "{{ istio_install_dir }}"
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+
+    - name: Download Istio
+      get_url:
+        url: "https://github.com/istio/istio/releases/download/{{ istio_version }}/istio-{{ istio_version }}-linux-arm64.tar.gz"
+        dest: "/tmp/istio-{{ istio_version }}.tar.gz"
+        mode: '0644'
+
+
+    - name: Extract Istio archive
+      unarchive:
+        src: "/tmp/istio-{{ istio_version }}.tar.gz"
+        dest: "{{ istio_install_dir }}"
+        remote_src: yes
+
+    - name: Move istioctl to /usr/local/bin
+      copy:
+        src: "{{ istio_install_dir }}/istio-{{ istio_version }}/bin/istioctl"
+        dest: /usr/local/bin/istioctl
+        mode: '0755'
+        remote_src: yes
+
+    - name: Verify istioctl version
+      command: istioctl version
+      register: istioctl_output
+      changed_when: false
+
+    - name: Print istioctl version
+      debug:
+        var: istioctl_output.stdout
+
+    - name: Install Istio with default profile
+      command: istioctl install --set profile=default -y
+      environment:
+        KUBECONFIG: /etc/kubernetes/admin.conf
+
+    - name: Wait for istio-system pods to be ready
+      shell: |
+        kubectl wait --for=condition=ready pod -l app=istiod -n istio-system --timeout=180s
+        kubectl wait --for=condition=ready pod -l istio=ingressgateway -n istio-system --timeout=180s
+      environment:
+        KUBECONFIG: /etc/kubernetes/admin.conf
+
+    - name: Label default namespace for automatic sidecar injection
+      command: kubectl label namespace default istio-injection=enabled --overwrite
+      environment:
+        KUBECONFIG: /etc/kubernetes/admin.conf
+
+
+    - name: Deploy Prometheus addon
+      command: kubectl apply -f {{ istio_install_dir }}/istio-{{ istio_version }}/samples/addons/prometheus.yaml
+      environment:
+        KUBECONFIG: /etc/kubernetes/admin.conf
+
+    - name: Deploy Jaeger addon
+      command: kubectl apply -f {{ istio_install_dir }}/istio-{{ istio_version }}/samples/addons/jaeger.yaml
+      environment:
+        KUBECONFIG: /etc/kubernetes/admin.conf
+
+    - name: Deploy Kiali addon
+      command: kubectl apply -f {{ istio_install_dir }}/istio-{{ istio_version }}/samples/addons/kiali.yaml
+      environment:
+        KUBECONFIG: /etc/kubernetes/admin.conf
+
+    - name: Wait for addons to be ready
+      shell: |
+        kubectl wait --for=condition=ready pod -l app=prometheus -n istio-system --timeout=120s
+        kubectl wait --for=condition=ready pod -l app=jaeger -n istio-system --timeout=120s
+        kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=kiali -n istio-system --timeout=120s
+      environment:
+        KUBECONFIG: /etc/kubernetes/admin.conf
+
+
+    ########## Install MetalLB ##########
+    - name: Copy MetalLB to VM
+      copy:
+        src: ansible/files/metallb-native.yaml
+        dest: /tmp/metallb-native.yaml
+        mode: '0644'
+
+    - name: Install MetalLB
+      become_user: vagrant
+      shell: kubectl apply -f /tmp/metallb-native.yaml
+
+    - name: Add IPAddressPool
+      copy:
+        dest: /etc/kubernetes/ip-address-pool.yaml
+        content: |
+          apiVersion: metallb.io/v1beta1
+          kind: IPAddressPool
+          metadata:
+            name: ip-address-pool
+            namespace: metallb-system
+          spec:
+            addresses:
+            - 192.168.56.90-192.168.56.99
+
+    - name: Apply IPAddressPool
+      become_user: vagrant
+      shell: |
+        kubectl apply -f /etc/kubernetes/ip-address-pool.yaml
+
+    - name: Configure L2Advertisement
+      copy:
+        dest: /etc/kubernetes/l2-advertisement.yaml
+        content: |
+          apiVersion: metallb.io/v1beta1
+          kind: L2Advertisement
+          metadata:
+            name: l2-advertisement
+            namespace: metallb-system
+
+    - name: Apply L2Advertisement
+      become_user: vagrant
+      shell:
+        kubectl apply -f /etc/kubernetes/l2-advertisement.yaml
+
+    - name: Wait for MetalLB
+      become_user: vagrant
+      shell: |
+        kubectl wait -n metallb-system -l app=metallb,component=controller --for=condition=ready pod --timeout=60s
+
+    - name: Add Kubernetes Dashboard repository
+      become_user: vagrant
+      shell: |
+        helm repo add kubernetes-dashboard https://kubernetes.github.io/dashboard/
+    - name: Install Kubernetes Dashboard
+      become_user: vagrant
+      kubernetes.core.helm:
+        name: kubernetes-dashboard
+        chart_ref: kubernetes-dashboard/kubernetes-dashboard
+        release_namespace: kubernetes-dashboard
+        create_namespace: true
+
+    - name: Copy Dashboard Manifest to VM
+      copy:
+        src: kubernetes-dashboard/dashboard-adminuser.yaml
+        dest: /tmp/dashboard-adminuser.yaml
+        mode: '0644'
+
+    - name: Create Admin User
+      become_user: vagrant
+      shell: kubectl apply -f /tmp/dashboard-adminuser.yaml

--- a/model-stack/templates/requests-rule.yaml
+++ b/model-stack/templates/requests-rule.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: request-rate-alert
-  namespace: monitoring
+  namespace: default
   labels:
     release: prometheus-stack
 spec:


### PR DESCRIPTION
Added sticky sessions for user routing, so users with the correct header are always redirected to the experimental (v2) version of the app, while others never see it (v1)