### PR TITLE
Inventory generation in Vagrantfile during Provisioning.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,7 +59,7 @@ Vagrant.configure("2") do |config|
         ansible.compatibility_mode = "2.0"
       end
     end
-
+  end
   # Generate ansible inventory after all VMs are up
   config.trigger.after :up do |trigger|
     trigger.name = "Generate ansible inventory config file"
@@ -68,14 +68,12 @@ Vagrant.configure("2") do |config|
 
         # active controller node
         f.puts "[ctrl]"
-        controller = active_nodes.find { |node| node[0] == "ctrl" }
-        f.puts "#{controller[0]} ansible_host=#{controller[1]}" if controller
+        f.puts "ctrl=92.168.56.100"
 
         # active worker nodes (loop through each one)
         f.puts "\n[nodes]"
-        workers = active_nodes.select { |node| node[0].start_with?("node-") }
-        workers.each do |worker|
-          f.puts "#{worker[0]} ansible_host=#{worker[1]}"
+        (1..WORKER_COUNT).each do |i|
+          f.puts "node-#{i}=192.168.56.#{i + 100}"
         end
       end
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,6 +8,8 @@ Vagrant.configure("2") do |config|
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "ansible/general.yaml"
     ansible.compatibility_mode = "2.0"
+    ansible.inventory_path = "inventory.cfg" 
+    ansible.limit = "all" 
     ansible.extra_vars = {
       worker_count: WORKER_COUNT
     }
@@ -34,6 +36,8 @@ Vagrant.configure("2") do |config|
     ctrl.vm.provision "ansible" do |ansible|
         ansible.playbook = "ansible/ctrl.yaml"
         ansible.compatibility_mode = "2.0"
+        ansible.inventory_path = "inventory.cfg"
+        ansible.limit = "all"
     end
   end
 
@@ -59,6 +63,8 @@ Vagrant.configure("2") do |config|
       node.vm.provision "ansible" do |ansible|
         ansible.playbook = "ansible/node.yaml"
         ansible.compatibility_mode = "2.0"
+        ansible.inventory_path = "inventory.cfg"
+        ansible.limit = "all"
       end
     end
   end


### PR DESCRIPTION
**This PR contributes to Assignment 2**

Added some configuration lines to `Vagrantfile` to make sure provisioning generates valid inventory.cfg for Ansible that contains all (and only) active nodes.